### PR TITLE
Merge with master

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,11 +83,13 @@ endif ()
 include(${PROJECT_SOURCE_DIR}/CMake/PackageConfig.cmake)
 
 if(HIGHFIVE_EXAMPLES)
-  add_subdirectory(src/examples)
+    file(GLOB HIGHFIVE_INC ${PROJECT_SOURCE_DIR}/include/highfive/*.hpp)
+    file(GLOB HIGHFIVE_INC_BITS ${PROJECT_SOURCE_DIR}/include/highfive/bits/*.hpp)
+    add_subdirectory(src/examples)
 endif()
 
 add_subdirectory(tests/unit)
 add_subdirectory(doc)
-export(PACKAGE HighFive)
+#export(PACKAGE HighFive)
 
 #install ( TARGETS  ... EXPORT <export_name> )

--- a/include/highfive/EigenUtils.hpp
+++ b/include/highfive/EigenUtils.hpp
@@ -1,0 +1,219 @@
+//
+// Created by nwknoblauch on 12/20/17.
+//
+
+#ifndef HIGHFIVE_EIGENUTILS_HPP
+#define HIGHFIVE_EIGENUTILS_HPP
+
+
+#ifdef H5_USE_EIGEN
+
+#ifdef USE_BLOSC
+
+#include <H5Ppublic.h>
+#include <highfive/H5Filter.hpp>
+#include "blosc_filter.h"
+
+#endif
+
+#include <highfive/H5File.hpp>
+#include <highfive/H5DataSet.hpp>
+#include <highfive/H5DataSpace.hpp>
+#include <highfive/H5Group.hpp>
+#include <highfive/H5Utility.hpp>
+
+namespace HighFive {
+
+
+    bool is_transposed(const DataSet &dataset) {
+        int doTranspose = 0;
+        if (dataset.hasAttribute("doTranspose")) {
+            dataset.getAttribute("doTranspose").read(doTranspose);
+        }
+        return (doTranspose != 0);
+    }
+
+    template<typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime, int Options>
+    void read_mat_h5(
+            const std::string &file_name,
+            const std::string &group_path,
+            const std::string &data_name,
+            Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options> &retmat,
+            std::vector<size_t> offsets = {0, 0},
+            std::vector<size_t> chunk_size = {}) {
+
+
+        typedef Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options> mat;
+        constexpr int transpose_type = Options == Eigen::RowMajor ? Eigen::ColMajor : Eigen::RowMajor;
+        HighFive::File file(file_name, HighFive::File::ReadOnly);
+
+        auto group = file.getGroup(group_path);
+
+
+        auto dataset = group.getDataSet(data_name);
+        bool transposed = is_transposed(dataset);
+        auto disk_dims = dataset.getSpace().getDimensions();
+        auto disk_chunk = disk_dims;
+        auto data_chunk = chunk_size;
+        std::vector<size_t> disk_offset = {0, 0};
+
+        //If chunk_size is empty, use the dimensions of the dataset on disk
+        // These will need to be transposed if the data is transposed
+        // The disk chunk size should NOT be transposed, however
+        if (chunk_size.empty()) {
+            std::copy(disk_dims.begin(), disk_dims.end(), std::back_inserter(chunk_size));
+            disk_chunk = chunk_size;
+            if (transposed) {
+                std::reverse(chunk_size.begin(), chunk_size.end());
+            }
+            offsets = {0, 0};
+        } else {
+            disk_offset = offsets;
+            disk_chunk = chunk_size;
+            //Do NOT transpose chunk size if chunk size is pre-specified
+            // DO transpose disk_chunk size if chunk size is pre-specified
+            if (transposed) {
+                std::reverse(disk_offset.begin(), disk_offset.end());
+                std::reverse(disk_chunk.begin(), disk_chunk.end());
+            }
+        }
+
+
+        if (((size_t) retmat.rows() < chunk_size[0]) || ((size_t) retmat.cols() < chunk_size[1])) {
+            //retmat must be resized so that the row and column number match the desired output row and column number
+            retmat.resize(chunk_size[0], chunk_size[1]);
+        }
+
+        auto sel = dataset.select(offsets, disk_chunk, std::vector<size_t>());
+        if (transposed) {
+            Eigen::Map<Eigen::Matrix<Scalar, ColsAtCompileTime, RowsAtCompileTime, transpose_type> > temp_mat(
+                    retmat.data(), disk_chunk[0], disk_chunk[1]);
+            sel.read(temp_mat);
+        } else {
+            Eigen::Map<Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options> > temp_mat(retmat.data(),
+                                                                                                       disk_chunk[0],
+                                                                                                       disk_chunk[1]);
+            sel.read(temp_mat);
+        }
+
+    }
+
+    template<typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime, int Options>
+    void write_mat_h5(
+            const std::string &file_name,
+            const std::string &group_path,
+            const std::string &data_name,
+            Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options> &matrix) {
+
+
+        typedef Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options> mat;
+
+
+        int transpose_int = 0;
+        std::vector<Eigen::Index> map_dims(2, 0);
+        map_dims[0] = matrix.rows();
+        map_dims[1] = matrix.cols();
+        assert(map_dims.size() == 2);
+
+        HighFive::File file(file_name, HighFive::File::ReadWrite | HighFive::File::Create);
+
+
+        Group group = file.createOrGetGroup(group_path);
+
+        auto plist = H5Pcreate(H5P_DATASET_CREATE);
+
+#ifdef USE_BLOSC
+        typedef typename details::remove_const<mat>::type type_no_const;
+        int r = 0;
+        r = register_blosc(nullptr, nullptr);
+
+        // Create a new file using the default property lists.
+        const size_t dim_buffer = details::array_dims<type_no_const>::value;
+
+        size_t chunkblocka = (size_t) (map_dims[0] < 1000 ? map_dims[0] : 1000);
+        size_t chunkblockb = (size_t) (map_dims[1] < 1000 ? map_dims[1] : 1000);
+        std::vector<size_t> cshape = {chunkblocka};
+        if (dim_buffer == 2) {
+            cshape.push_back(chunkblockb);
+        }
+        Filter filter(cshape, FILTER_BLOSC, r);
+        // Create a dataset with double precision floating points
+        plist = filter.getId();
+#endif
+
+        Eigen::Map<mat> w_mat(matrix.data(), map_dims[0], map_dims[1]);
+        DataSpace ds = DataSpace::From(w_mat);
+
+        DataSet dataset = group.createDataSet(data_name, ds, AtomicType<Scalar>(), plist);
+        auto transpose_attr = dataset.createAttribute<int>("doTranspose", DataSpace::From(transpose_int));
+        transpose_attr.write(transpose_int);
+        dataset.write(w_mat);
+    }
+
+
+    template<typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime, int Options>
+    void write_mat_h5_transpose(
+            const std::string &file_name,
+            const std::string &group_path,
+            const std::string &data_name,
+            Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options> &matrix) {
+
+
+        typedef Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options> mat;
+        typedef std::conditional_t<std::is_same_v<std::integral_constant<int, Options>, std::integral_constant<int, Eigen::RowMajor> >,
+                std::integral_constant<decltype(Eigen::ColMajor), Eigen::ColMajor>,
+                std::integral_constant<decltype(Eigen::ColMajor), Eigen::RowMajor> > Transpose_Type;
+        constexpr int mappedRows = ColsAtCompileTime;
+        constexpr int mappedCols = RowsAtCompileTime;
+        typedef Eigen::Matrix<Scalar, mappedRows, mappedCols, Transpose_Type::value> transpose_mat;
+
+
+        int transpose_int = 1;
+        std::vector<Eigen::Index> map_dims(2, 0);
+        map_dims[0] = matrix.rows();
+        map_dims[1] = matrix.cols();
+        assert(map_dims.size() == 2);
+        std::reverse(map_dims.begin(), map_dims.end());
+
+
+        HighFive::File file(file_name, HighFive::File::ReadWrite | HighFive::File::Create);
+
+
+        Group group = file.createOrGetGroup(group_path);
+
+
+        auto plist = H5Pcreate(H5P_DATASET_CREATE);
+
+#ifdef USE_BLOSC
+        typedef typename details::remove_const<mat>::type type_no_const;
+        int r = 0;
+        r = register_blosc(nullptr, nullptr);
+
+        // Create a new file using the default property lists.
+        const size_t dim_buffer = details::array_dims<type_no_const>::value;
+
+        size_t chunkblocka = (size_t) (map_dims[0] < 1000 ? map_dims[0] : 1000);
+        size_t chunkblockb = (size_t) (map_dims[1] < 1000 ? map_dims[1] : 1000);
+        std::vector<size_t> cshape = {chunkblocka};
+        if (dim_buffer == 2) {
+            cshape.push_back(chunkblockb);
+        }
+        Filter filter(cshape, FILTER_BLOSC, r);
+        // Create a dataset with double precision floating points
+        plist = filter.getId();
+#endif
+
+        Eigen::Map<transpose_mat> w_mat(matrix.data(), map_dims[0], map_dims[1]);
+        DataSpace ds = DataSpace::From(w_mat);
+
+        DataSet dataset = group.createDataSet(data_name, ds, AtomicType<Scalar>(), plist);
+        auto transpose_attr = dataset.createAttribute<int>("doTranspose", DataSpace::From(transpose_int));
+        transpose_attr.write(transpose_int);
+        dataset.write(w_mat);
+    }
+
+
+#endif
+}
+
+#endif //HIGHFIVE_EIGENUTILS_HPP

--- a/include/highfive/H5DataSpace.hpp
+++ b/include/highfive/H5DataSpace.hpp
@@ -84,6 +84,14 @@ class DataSpace : public Object {
         template<typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime, int Options>
         static DataSpace From(const Eigen::Matrix <Scalar, RowsAtCompileTime, ColsAtCompileTime, Options> &mat);
 
+        template<typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime, int Options>
+        static DataSpace
+        From(const Eigen::Map<const Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options> > &mat);
+
+        template<typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime, int Options>
+        static DataSpace
+        From(const Eigen::Map<Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options> > &mat);
+
 #endif
     /// Create a dataspace matching the container dimensions and size
     /// Supported Containers are:

--- a/include/highfive/bits/H5Converter_misc.hpp
+++ b/include/highfive/bits/H5Converter_misc.hpp
@@ -268,8 +268,8 @@ struct data_converter<CArray,
             }
 
             inline typename type_of_array<Scalar>::type *transform_read(Matrix &matrix) {
-                assert(_dims[0] == matrix.rows());
-                assert(_dims[1] == matrix.cols());
+                assert(_dims[0] == (unsigned long) matrix.rows());
+                assert(_dims[1] == (unsigned long) matrix.cols());
 
                 auto return_pointer = matrix.data();
 
@@ -535,7 +535,7 @@ struct data_converter<std::string, void> {
                 _c_vec.resize(255 * _space.getDimensions()[0]);
                 std::vector<char>::iterator it = _c_vec.begin();
                 const size_t vs = vec.size();
-                for (int i = 0; i < vs; i++) {
+                for (size_t i = 0; i < vs; i++) {
                     auto tb = vec[i].begin();
                     auto te = vec[i].end();
                     std::copy(tb, te, it);

--- a/include/highfive/bits/H5Dataspace_misc.hpp
+++ b/include/highfive/bits/H5Dataspace_misc.hpp
@@ -121,11 +121,23 @@ inline DataSpace DataSpace::From(const std::vector<Value>& container) {
     template<typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime, int Options>
     inline DataSpace
     DataSpace::From(const Eigen::Matrix <Scalar, RowsAtCompileTime, ColsAtCompileTime, Options> &mat) {
-        std::vector<size_t> dims(2);
-        dims[0] = mat.rows();
-        dims[1] = mat.cols();
-        return DataSpace(dims);
+        return (DataSpace(details::get_dim_vector<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options>(mat)));
     }
+
+    template<typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime, int Options>
+    inline DataSpace
+    DataSpace::From(
+            const Eigen::Map<const Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options> > &mat) {
+        return (DataSpace(details::get_dim_vector<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options>(mat)));
+    }
+
+    template<typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime, int Options>
+    inline DataSpace
+    DataSpace::From(const Eigen::Map<Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options> > &mat) {
+        return (DataSpace(details::get_dim_vector<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options>(mat)));
+    }
+
+
 
 #endif
 

--- a/include/highfive/bits/H5Node_traits.hpp
+++ b/include/highfive/bits/H5Node_traits.hpp
@@ -69,7 +69,7 @@ class NodeTraits {
     ///
     Group createGroup(const std::string& group_name);
 
-    Group createGroups(const std::vector<std::string> group_names);
+    Group createGroups(const std::vector<std::string> &group_names);
 
     ///
     /// \brief open an existing group with the name group_name
@@ -77,6 +77,8 @@ class NodeTraits {
     /// \return the group object
     ///
     Group getGroup(const std::string& group_name) const;
+
+    Group createOrGetGroup(const std::string &group_name);
 
     ///
     /// \brief return the number of leaf objects of the node / group
@@ -101,8 +103,9 @@ class NodeTraits {
     /// false
     bool exist(const std::string& node_name) const;
 
+    Group createGroups_rec(const std::vector<std::string> &group_names, const std::string &group_name);
   private:
-    Group createGroups_rec(std::vector<std::string> group_names, const std::string group_name);
+
     typedef Derivate derivate_type;
 };
 }

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -95,28 +95,42 @@ inline Group NodeTraits<Derivate>::createGroup(const std::string& group_name) {
 }
 
     template<typename Derivate>
-    inline Group NodeTraits<Derivate>::createGroups_rec(std::vector<std::string> group_names, std::string group_name) {
+    inline Group NodeTraits<Derivate>::createOrGetGroup(const std::string &group_name) {
+        if (this->exist(group_name)) {
+            return (this->getGroup(group_name));
+        } else {
+            return (this->createGroup(group_name));
+        }
+
+    }
+
+
+    template<typename Derivate>
+    inline Group
+    NodeTraits<Derivate>::createGroups_rec(const std::vector<std::string> &group_names, const std::string &group_name) {
         Group group = this->createGroup(group_name);
         if (group_names.empty()) {
             return (group);
         } else {
-            group_name = group_names.begin();
-            Group last_group = group.createGroups_rec(
-                    std::vector<std::string>(group_names.begin() + 1, group_names.end()),
-                    group_name);
+            std::string new_group_name = group_names[0];
+            std::vector<std::string> new_group_names(group_names.begin() + 1, group_names.end());
+            Group last_group = group.createGroups_rec(new_group_names, new_group_name);
             return (last_group);
         }
     }
 
 
     template<typename Derivate>
-    inline Group NodeTraits<Derivate>::createGroups(std::vector<std::string> group_names) {
+    inline Group NodeTraits<Derivate>::createGroups(const std::vector<std::string> &group_names) {
         if (group_names.empty()) {
-            return (this);
+            Group group;
+            auto id = static_cast<const Derivate *>(this)->getId();
+            group._hid = id;
+            return (group);
         } else {
-            std::string group_name = group_names.begin();
-            Group group = this.createGroups_rec(std::vector<std::string>(group_names.begin() + 1, group_names.end()),
-                                                group_name);
+            std::string group_name = group_names[0];
+            std::vector<std::string> new_group_names(group_names.begin() + 1, group_names.end());
+            Group group = this->createGroups_rec(new_group_names, group_name);
             return (group);
         }
     }

--- a/include/highfive/bits/H5Utils.hpp
+++ b/include/highfive/bits/H5Utils.hpp
@@ -86,9 +86,46 @@ struct array_dims<T[N]> {
             static const size_t value = (RowsAtCompileTime != 1 ? 1 : 0) + (ColsAtCompileTime != 1 ? 1 : 0);
         };
         template<typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime, int Options>
+        struct array_dims<Eigen::Map<const Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options> > > {
+            static const size_t value = (RowsAtCompileTime != 1 ? 1 : 0) + (ColsAtCompileTime != 1 ? 1 : 0);
+        };
+        template<typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime, int Options>
+        struct array_dims<const Eigen::Map<Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options> > > {
+            static const size_t value = (RowsAtCompileTime != 1 ? 1 : 0) + (ColsAtCompileTime != 1 ? 1 : 0);
+        };
+        template<typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime, int Options>
         struct array_dims<Eigen::Map<Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options> > > {
             static const size_t value = (RowsAtCompileTime != 1 ? 1 : 0) + (ColsAtCompileTime != 1 ? 1 : 0);
         };
+
+        template<typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime, int Options>
+        std::vector<size_t>
+        get_dim_vector(const Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options> &mat) {
+            const size_t dim_num = array_dims<Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options> >::value;
+            std::vector<size_t> dims(dim_num);
+            if (dim_num > 0) {
+                dims[0] = mat.rows();
+            }
+            if (dim_num > 1) {
+                dims[1] = mat.cols();
+            }
+            return dims;
+        }
+
+        template<typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime, int Options>
+        std::vector<size_t>
+        get_dim_vector(const Eigen::Map<Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options> > &mat) {
+            const size_t dim_num = array_dims<Eigen::Map<Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options> > >::value;
+            std::vector<size_t> dims(dim_num);
+            if (dim_num > 0) {
+                dims[0] = mat.rows();
+            }
+            if (dim_num > 1) {
+                dims[1] = mat.cols();
+            }
+            return dims;
+        }
+
 
 #endif
 
@@ -147,6 +184,14 @@ struct type_of_array<std::vector<T> > {
         };
         template<typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime, int Options>
         struct type_of_array<Eigen::Map<Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options> > > {
+            typedef typename type_of_array<Scalar>::type type;
+        };
+        template<typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime, int Options>
+        struct type_of_array<const Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options> > {
+            typedef typename type_of_array<Scalar>::type type;
+        };
+        template<typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime, int Options>
+        struct type_of_array<Eigen::Map<const Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options> > > {
             typedef typename type_of_array<Scalar>::type type;
         };
 #endif
@@ -240,6 +285,7 @@ template <typename Type>
 struct remove_const<Type const> {
     typedef Type type;
 };
+
 
 // shared ptr portability
 namespace Mem {

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -14,10 +14,10 @@ if(NOT Boost_USE_STATIC_LIBS)
 endif()
 
 ## base tests
-#file(GLOB tests_high_five_src "*base.cpp")
 
 
-add_executable(tests_high_five_bin tests_high_five_base.cpp)
+add_executable(tests_high_five_bin tests_high_five_base.cpp ${HIGHFIVE_INC} ${HIGHFIVE_INC_BITS})
+
 target_link_libraries(tests_high_five_bin ${Boost_UNIT_TEST_FRAMEWORK_LIBRARIES}
   ${HDF5_C_LIBRARIES})
 
@@ -36,7 +36,7 @@ if(HIGHFIVE_PARALLEL_HDF5)
   target_link_libraries(tests_high_five_bin ${MPI_C_LIBRARIES})
 endif()
 
-add_test(NAME tests_high_five COMMAND tests_high_five_bin)
+add_test(NAME tests_high_five COMMAND tests_high_five_bin --log_level=test_suite)
 
 ## if the compiler support C++11
 ## lets recompile the base tests with C++11 support


### PR DESCRIPTION
The `converter` struct still needs to be split into reader and writer converters.  This is a source of a lot of grossness.